### PR TITLE
Allow calling `Metrics::Provider` without block.

### DIFF
--- a/lib/metrics/provider.rb
+++ b/lib/metrics/provider.rb
@@ -11,6 +11,9 @@ module Metrics
 		self.const_defined?(:Backend)
 	end
 	
+	module Provider
+	end
+	
 	# A module which contains tracing specific wrappers.
 	module Singleton
 		def metrics_provider
@@ -31,7 +34,9 @@ module Metrics
 			
 			klass.prepend(provider)
 			
-			provider.module_exec(&block)
+			provider.module_exec(&block) if block_given?
+			
+			return provider
 		end
 	else
 		def self.Provider(klass, &block)

--- a/test/metrics/provider.rb
+++ b/test/metrics/provider.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2021-2022, by Samuel Williams.
+
+unless ENV['METRICS_BACKEND']
+	abort "No backend specified, tests will fail!"
+end
+
+require 'metrics/provider'
+
+describe Metrics::Provider do
+	let(:my_class) {Class.new}
+	
+	it "works without a block" do
+		provider = Metrics::Provider(my_class)
+		expect(provider).to be_equal(my_class.metrics_provider)
+	end
+end


### PR DESCRIPTION
Consistency with <https://github.com/socketry/traces/pull/7>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
