### PR TITLE
Simplify metrics provider instrumentation

### DIFF
--- a/lib/metrics/provider.rb
+++ b/lib/metrics/provider.rb
@@ -14,21 +14,11 @@ module Metrics
 	module Provider
 	end
 	
-	# A module which contains tracing specific wrappers.
-	module Singleton
-		def metrics_provider
-			@metrics_provider ||= Module.new
-		end
-	end
-	
-	private_constant :Singleton
-	
 	# Bail out if there is no backend configured.
 	if self.enabled?
 		# Extend the specified class in order to emit traces.
 		def self.Provider(klass, &block)
-			klass.extend(Singleton)
-			provider = klass.metrics_provider
+			provider = Module.new
 			klass.prepend(provider)
 			
 			provider.module_exec(&block) if block_given?

--- a/test/metrics/backend/.capture/app.rb
+++ b/test/metrics/backend/.capture/app.rb
@@ -8,12 +8,14 @@ class App
 	end
 end
 
-Metrics::Provider(App) do
-	MY_METRIC = Metrics.metric(:my_metric, :gauge, description: "My metric", unit: "seconds")
-	
-	def call
-		MY_METRIC.emit(1, tags: ['environment:test'])
+class App
+	Metrics::Provider(self) do
+		MY_METRIC = Metrics.metric(:my_metric, :gauge, description: "My metric", unit: "seconds")
 		
-		super
+		def call
+			MY_METRIC.emit(1, tags: ['environment:test'])
+			
+			super
+		end
 	end
 end

--- a/test/metrics/provider.rb
+++ b/test/metrics/provider.rb
@@ -14,6 +14,8 @@ describe Metrics::Provider do
 	
 	it "works without a block" do
 		provider = Metrics::Provider(my_class)
-		expect(provider).to be_equal(my_class.metrics_provider)
+		
+		expect(provider).to be_a(Module)
+		expect(my_class.ancestors).to be(:include?, provider)
 	end
 end


### PR DESCRIPTION
## Summary
- replace the cached metrics provider module with a fresh anonymous module per provider declaration
- update the provider test to assert the returned module is prepended
- keep the capture fixture aligned with the in-class provider style

## Tests
- chruby 4.0.5 && bundle exec sus